### PR TITLE
Fix GitHub Actions permissions for Pages deployment

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
This PR adds the necessary permissions for GitHub Actions to push to the gh-pages branch during documentation deployment. This addresses the 403 error that occurs when the GitHub Pages workflow tries to push to the gh-pages branch.

This PR ONLY includes the permissions fix and no other changes, making it safe to merge directly into main.

## Summary by Sourcery

CI:
- Add contents write permission to docs workflow to allow pushing to the gh-pages branch