### PR TITLE
Fix GitHub Pages workflow with permissions and force_orphan

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
       - uses: actions/checkout@v3
@@ -29,3 +31,4 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./site
+          force_orphan: true


### PR DESCRIPTION
This PR addresses two issues with the GitHub Pages deployment workflow:

1. Adds explicit write permissions to allow the workflow to push to the gh-pages branch
2. Adds force_orphan option to handle diverging histories when pushing

The force_orphan option creates a fresh history for the gh-pages branch on each deployment, which resolves conflicts from diverging histories that were causing failures in Dependabot PRs.

## Summary by Sourcery

Fix GitHub Pages deployment workflow by granting write permissions and using force_orphan to prevent errors from diverging histories

CI:
- Add explicit write permissions for GitHub Actions to push to the gh-pages branch
- Enable force_orphan option in the deployment step to handle diverging branch histories