### PR TITLE
Update development with GitHub Pages workflow fix

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
       - uses: actions/checkout@v3
@@ -25,7 +27,8 @@ jobs:
         run: mkdocs build --strict
 
       - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./site
+          force_orphan: true


### PR DESCRIPTION
This PR updates the development branch with the GitHub Pages workflow fixes from main, which includes:

1. Adding explicit write permissions to the workflow
2. Using force_orphan for clean deployments

These changes have already been tested and merged into main.