### PR TITLE
Update GitHub Actions dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,11 +12,11 @@ jobs:
     # name: lint_and_type (${{ github.event_name }})
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - uses: prefix-dev/setup-pixi@v0.8.3
+      - uses: prefix-dev/setup-pixi@v0.8.8
         with:
           pixi-version: latest
           manifest-path: pyproject.toml
@@ -46,9 +46,9 @@ jobs:
         python-version: [3.9, 3.10, 3.11, 3.12]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: prefix-dev/setup-pixi@v0.8.3
+      - uses: prefix-dev/setup-pixi@v0.8.8
         with:
           pixi-version: latest
           manifest-path: pyproject.toml

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -15,17 +15,17 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v2
+        uses: github/codeql-action/init@v3
         with:
           languages: python
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v2
+        uses: github/codeql-action/autobuild@v3
 
       - name: Run CodeQL Analysis
-        uses: github/codeql-action/analyze@v2
+        uses: github/codeql-action/analyze@v3
         with:
           category: '/language:python'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,10 +13,10 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.x'
 


### PR DESCRIPTION
This PR updates GitHub Actions dependencies from main to development branch:

- actions/checkout from v3 to v4
- actions/setup-python from v4 to v5
- prefix-dev/setup-pixi from v0.8.3 to v0.8.8
- github/codeql-action from v2 to v3
- peaceiris/actions-gh-pages from v3 to v4

These updates improve security and functionality of the CI/CD pipelines.

## Summary by Sourcery

Update GitHub Actions dependencies to their latest versions to enhance security and functionality of the CI/CD pipelines.

Enhancements:
- Upgrade actions/checkout from v3 to v4 across CI, CodeQL, and docs workflows
- Bump prefix-dev/setup-pixi from v0.8.3 to v0.8.8 in CI workflows
- Update github/codeql-action init, autobuild, and analyze steps from v2 to v3
- Upgrade actions/setup-python from v4 to v5 in the docs workflow