### PR TITLE
bump pixi

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,6 @@ jobs:
         run: pixi run -e dev test
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v5
         with:
           files: coverage.xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: prefix-dev/setup-pixi@v0.8.8
+      - uses: prefix-dev/setup-pixi@v0.8.10
         with:
           pixi-version: latest
           manifest-path: pyproject.toml
@@ -48,7 +48,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: prefix-dev/setup-pixi@v0.8.8
+      - uses: prefix-dev/setup-pixi@v0.8.10
         with:
           pixi-version: latest
           manifest-path: pyproject.toml


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Bump prefix-dev/setup-pixi action to v0.8.10 in both jobs of the CI pipeline