### PR TITLE
Fix: MCP Server Tools Registration Issue

### DIFF
--- a/tests/mcp/test_server.py
+++ b/tests/mcp/test_server.py
@@ -263,7 +263,7 @@ class TestPytestAnalyzerMCPServer:
         assert "host='localhost'" in repr_str
         assert "port=8080" in repr_str
         assert "running=False" in repr_str
-        assert "tools=0" in repr_str
+        assert "tools=8" in repr_str  # Server now auto-registers 8 tools
         assert "resources=0" in repr_str
 
 
@@ -330,7 +330,7 @@ class TestMCPServerIntegration:
 
         # Verify initial state
         assert not server.is_running
-        assert len(server.get_registered_tools()) == 0
+        assert len(server.get_registered_tools()) == 8  # Server auto-registers 8 tools
 
         # Register a tool
         def test_handler():
@@ -345,8 +345,8 @@ class TestMCPServerIntegration:
 
             server.register_tool("test_tool", "Test tool", test_handler)
 
-            # Verify tool registration
-            assert len(server.get_registered_tools()) == 1
+            # Verify tool registration (8 auto-registered + 1 test tool)
+            assert len(server.get_registered_tools()) == 9
             assert "test_tool" in server.get_registered_tools()
 
         # Register a resource

--- a/tests/mcp/test_server.py
+++ b/tests/mcp/test_server.py
@@ -211,13 +211,14 @@ class TestPytestAnalyzerMCPServer:
             async with server.lifespan():
                 raise ValueError("Test exception")
 
-    def test_get_server_capabilities_empty(self):
-        """Test server capabilities with no registered tools/resources."""
+    def test_get_server_capabilities_with_auto_registered_tools(self):
+        """Test server capabilities with automatically registered tools."""
         server = PytestAnalyzerMCPServer()
         capabilities = server._get_server_capabilities()
 
-        assert capabilities["tools"] is None
-        assert capabilities["resources"] is None
+        # Server now automatically registers 8 tools during initialization
+        assert capabilities["tools"] == {"listChanged": True}
+        assert capabilities["resources"] is None  # No resources registered by default
 
     def test_get_server_capabilities_with_tools_and_resources(self):
         """Test server capabilities with registered tools and resources."""

--- a/tests/mcp/test_server.py
+++ b/tests/mcp/test_server.py
@@ -21,7 +21,9 @@ class TestPytestAnalyzerMCPServer:
         assert server.port == 8000
         assert server.settings is not None
         assert not server.is_running
-        assert len(server.get_registered_tools()) == 0
+        assert (
+            len(server.get_registered_tools()) == 8
+        )  # Should have all AVAILABLE_TOOLS registered
         assert len(server.get_registered_resources()) == 0
 
     def test_init_custom_settings(self):


### PR DESCRIPTION
# Fix: MCP Server Tools Registration Issue

## 🐛 Problem Summary
MCP server was initializing successfully but **no tools were being registered**, making the server completely non-functional despite passing all tests.

## 🔍 Root Cause Analysis
- **Integration Gap**: `AVAILABLE_TOOLS` were defined but never registered with the server instance
- **False Positive Test**: Test explicitly expected `0` tools instead of `8`, codifying the bug:
  ```python
  assert len(server.get_registered_tools()) == 0  # ❌ Wrong expectation
  ```
- **Silent Failure**: Server appeared to work but was missing core functionality

## ✅ Solution Implemented

### 1. **Server Registration Fix**
- Added missing `AVAILABLE_TOOLS` import
- Implemented `_register_available_tools()` method
- Automatic tool registration during server initialization

### 2. **Test Correction** 
- Fixed test expectation from `0` to `8` registered tools
- Now properly validates that tools are registered

### 3. **Quality Process Improvement**
- Added quality improvement documentation
- Identified testing blind spots for future prevention

## 🛠️ Tools Now Registered (8 total)
- ✅ `suggest_fixes`: Generate fix suggestions from pytest output
- ✅ `run_and_analyze`: Run pytest and analyze results  
- ✅ `apply_suggestion`: Apply fixes with validation
- ✅ `validate_suggestion`: Validate fixes without applying
- ✅ `get_failure_summary`: Get test failure statistics
- ✅ `get_test_coverage`: Get test coverage information
- ✅ `update_config`: Update analyzer configuration
- ✅ `nl_query`: Natural language query interface

## 🧪 Test Plan
- [x] MCP server initializes successfully
- [x] All 8 tools are registered during initialization
- [x] Server can start and handle STDIO connections
- [x] Tools are callable via MCP protocol
- [x] Updated test passes with correct expectations
- [x] Pre-commit hooks pass (formatting applied)

## 📈 Impact
- **Before**: MCP server was completely non-functional (0 tools)
- **After**: Full MCP functionality with all 8 tools available
- **Quality**: Improved testing to catch integration gaps

## 🔗 Related Issues
This resolves the "serious MCP server failure" reported where the server appeared to work but had no callable tools.

## 🎯 Quality Lessons Learned
- **False positive tests** can be more dangerous than no tests
- **Integration testing** is critical for modular architectures  
- **Test what SHOULD happen**, not just absence of errors
- **Explicit positive assertions** prevent silent failures

🤖 Generated with [Claude Code](https://claude.ai/code)

## Summary by Sourcery

Ensure the MCP server properly registers all available tools on startup and update tests to reflect the correct tool count

Bug Fixes:
- Register AVAILABLE_TOOLS with the server during initialization to restore tool functionality
- Correct the test expectation to assert 8 registered tools instead of 0

Enhancements:
- Add a dedicated _register_available_tools method to automate tool registration and log the number of tools

Tests:
- Update test_server.py to expect all 8 tools to be registered on server initialization